### PR TITLE
Hotfix indentation typo

### DIFF
--- a/wintersmith-handlebars.coffee
+++ b/wintersmith-handlebars.coffee
@@ -43,7 +43,7 @@ module.exports = (env, callback) ->
           rendered = @tpl locals
           callback null, new Buffer rendered
       catch error
-      callback error
+          callback error
 
   HandlebarsTemplate.fromFile = (filepath, callback) ->
     fs.readFile filepath.full, (error, contents) ->


### PR DESCRIPTION
This callback is supposed to be called inside of the catch block. Otherwise, it's called every time when "render" function is being called, which possibly brings down a webserver.
